### PR TITLE
Is this fork still necessary?

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (runner, options) {
 	var logFd, 
 	stack = {};
 
-	var outputfile = getProp(options, 'reporterOptions.outputFile');
+	var outputfile = getPrefixedProp(options, 'outputFile');
 	if (outputfile) {
 		mkdirpSync(path.dirname(outputfile));
 		logFd = fs.openSync(outputfile, 'w');
@@ -18,7 +18,7 @@ module.exports = function (runner, options) {
 
 	runner.on('test end', function(test){
 
-		var file = getProp(options, 'reporterOptions.useFileFullPath') ? test.file : test.file.substr(test.file.indexOf(process.cwd()) + process.cwd().length + 1);
+		var file = getPrefixedProp(options, 'useFileFullPath') ? test.file : test.file.substr(test.file.indexOf(process.cwd()) + process.cwd().length + 1);
 		stackF = stack[file];
 		if(!stackF){
 			stackF = stack[file] = [];
@@ -99,6 +99,10 @@ function escape(str){
 				.replace(/>/g, '&gt;')
 				.replace(/"/g, '&quot;')
 				.replace(/'/g, '&apos;');
+}
+
+function getPrefixedProp(map, keys) {
+	return getProp(map, 'reporterOptions.' + keys) || getProp(map, 'mtsc.' + keys);
 }
 
 function getProp(map, keys){

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (runner, options) {
 	var logFd, 
 	stack = {};
 
-	var outputfile = getProp(options, 'mstc.outputFile');
+	var outputfile = getProp(options, 'reporterOptions.outputFile');
 	if (outputfile) {
 		mkdirpSync(path.dirname(outputfile));
 		logFd = fs.openSync(outputfile, 'w');
@@ -18,7 +18,7 @@ module.exports = function (runner, options) {
 
 	runner.on('test end', function(test){
 
-		var file = getProp(options, 'mstc.useFileFullPath') ? test.file : test.file.substr(test.file.indexOf(process.cwd()) + process.cwd().length + 1);
+		var file = getProp(options, 'reporterOptions.useFileFullPath') ? test.file : test.file.substr(test.file.indexOf(process.cwd()) + process.cwd().length + 1);
 		stackF = stack[file];
 		if(!stackF){
 			stackF = stack[file] = [];

--- a/test/MochaGenericReport.js
+++ b/test/MochaGenericReport.js
@@ -9,50 +9,104 @@ describe('Mocha Sonar Generic Report', function(){
 
 	describe('Report', function(){
 
-		it('Report To File Success', function(){
+        it('Report To File Success with reporterOptions prefix', function(){
+            testReportToFileSuccess('reporterOptions')
+        });
 
-			resetTest();
+        it('Report To File Success with mtsc prefix', function(){
+            testReportToFileSuccess('mtsc')
+        });
 
-			var runner = new Runner();
-			report(runner, {
-				reporterOptions: {
-					outputFile: reportFile
-				}
-			});
-			runner.run([
-				new Test('Success Test', null, null, 1, 'success', process.cwd()+'/tmp/test.js')
-			]);
+        it('Report To File Success And Error with reporterOptions prefix', function(){
+            testReportToFileSuccessAndError('reporterOptions')
+        });
 
-			var actualContent = getFileContent(reportFile);
-			var expected = `<unitTest version="1">
+        it('Report To File Success And Error with mtsc prefix', function(){
+            testReportToFileSuccessAndError('mtsc')
+        });
+
+        it('Report To File With FullPath with reporterOptions prefix', function(){
+            testReportToFileWithFullPath('reporterOptions')
+        });
+
+        it('Report To File With FullPath with mtsc prefix', function(){
+            testReportToFileWithFullPath('mtsc')
+        });
+
+		it('Report To Stdout', function(){
+            testReportToStdout();
+		});
+
+	});
+
+});
+
+function config(prefix, config) {
+    var ret = {};
+    ret[prefix] = config
+    return ret;
+}
+
+function testReportToStdout() {
+    resetTest();
+    var actualContent = "";
+    var unhook = hookStdout(function(str, encoding, fd){
+        actualContent += str;
+    });
+    var runner = new Runner();
+    report(runner, {});
+    runner.run([
+        new Test('Success Test', null, null, 1, 'success', process.cwd() + '/tmp/test.js')
+    ]);
+
+    var expected = `<unitTest version="1">
 	<file path="tmp/test.js">
 		<testCase name="Success Test" duration="1">
 		</testCase>
 	</file>
 </unitTest>
 `;
-			assertXML(actualContent, expected);
+    unhook();
+    assertXML(actualContent, expected);
+}
 
-		});
+function testReportToFileSuccess(prefix) {
+    resetTest();
 
-		it('Report To File Success And Error', function(){
+    var runner = new Runner();
+    report(runner, config(prefix, {
+        outputFile: reportFile
+    }));
+    runner.run([
+        new Test('Success Test', null, null, 1, 'success', process.cwd()+'/tmp/test.js')
+    ]);
 
-			resetTest();
+    var actualContent = getFileContent(reportFile);
+    var expected = `<unitTest version="1">
+	<file path="tmp/test.js">
+		<testCase name="Success Test" duration="1">
+		</testCase>
+	</file>
+</unitTest>
+`;
+    assertXML(actualContent, expected);
+}
 
-			var runner = new Runner();
-			report(runner, {
-                reporterOptions: {
-					outputFile: reportFile,
-					useFileFullPath: false
-				}
-			});
-			runner.run([
-				new Test('Success Test', null, null, 1, 'success', process.cwd()+'/tmp/test.js'),
-				new Test('Success Test', "IO error", "File not found", 2, 'failed', process.cwd()+'/tmp/test.js'),
-			]);
+function testReportToFileSuccessAndError(prefix) {
+    resetTest();
 
-			var actualContent = getFileContent(reportFile);
-			var expected = `<unitTest version="1">
+    var runner = new Runner();
+    report(runner, config(prefix, {
+        outputFile: reportFile,
+        useFileFullPath: false
+    }));
+    runner.run([
+        new Test('Success Test', null, null, 1, 'success', process.cwd()+'/tmp/test.js'),
+        new Test('Success Test', "IO error", "File not found", 2, 'failed', process.cwd()+'/tmp/test.js'),
+    ]);
+
+    var actualContent = getFileContent(reportFile);
+    var expected = `<unitTest version="1">
 	<file path="tmp/test.js">
 		<testCase name="Success Test" duration="1">
 		</testCase>
@@ -62,65 +116,31 @@ describe('Mocha Sonar Generic Report', function(){
 	</file>
 </unitTest>
 `;
-			assertXML(actualContent, expected);
+    assertXML(actualContent, expected);
+}
 
-		});
+function testReportToFileWithFullPath(prefix) {
+    resetTest();
 
-		it('Report To File With FullPath', function(){
+    var runner = new Runner();
+    report(runner, config(prefix, {
+        outputFile: reportFile,
+        useFileFullPath: true
+    }));
+    runner.run([
+        new Test('Success Test', null, null, 1, 'success', '/tmp/test.js')
+    ]);
 
-			resetTest();
-
-			var runner = new Runner();
-			report(runner, {
-                reporterOptions: {
-					outputFile: reportFile,
-					useFileFullPath: true
-				}
-			});
-			runner.run([
-				new Test('Success Test', null, null, 1, 'success', '/tmp/test.js')
-			]);
-
-			var actualContent = getFileContent(reportFile);
-			var expected = `<unitTest version="1">
+    var actualContent = getFileContent(reportFile);
+    var expected = `<unitTest version="1">
 	<file path="/tmp/test.js">
 		<testCase name="Success Test" duration="1">
 		</testCase>
 	</file>
 </unitTest>
 `;
-			assertXML(actualContent, expected);
-
-		});
-
-		it('Report To Stdout', function(){
-
-			resetTest();
-			var actualContent = "";
-			var unhook = hookStdout(function(str, encoding, fd){
-				actualContent += str;
-			});
-			var runner = new Runner();
-			report(runner, {});
-			runner.run([
-				new Test('Success Test', null, null, 1, 'success', process.cwd() + '/tmp/test.js')
-			]);
-
-			var expected = `<unitTest version="1">
-	<file path="tmp/test.js">
-		<testCase name="Success Test" duration="1">
-		</testCase>
-	</file>
-</unitTest>
-`;
-			unhook();
-			assertXML(actualContent, expected);
-
-		});
-
-	});
-
-});
+    assertXML(actualContent, expected);
+}
 
 function replaceAll(string, search, replacement) {
     return string.split(search).join(replacement);

--- a/test/MochaGenericReport.js
+++ b/test/MochaGenericReport.js
@@ -15,7 +15,7 @@ describe('Mocha Sonar Generic Report', function(){
 
 			var runner = new Runner();
 			report(runner, {
-				mstc: {
+				reporterOptions: {
 					outputFile: reportFile
 				}
 			});
@@ -41,7 +41,7 @@ describe('Mocha Sonar Generic Report', function(){
 
 			var runner = new Runner();
 			report(runner, {
-				mstc: {
+                reporterOptions: {
 					outputFile: reportFile,
 					useFileFullPath: false
 				}
@@ -72,7 +72,7 @@ describe('Mocha Sonar Generic Report', function(){
 
 			var runner = new Runner();
 			report(runner, {
-				mstc: {
+                reporterOptions: {
 					outputFile: reportFile,
 					useFileFullPath: true
 				}


### PR DESCRIPTION
(Please ignore the diff. I would have opened an Issue, but Issues are disabled for this repo.)

I came upon this repo via npm. I see it is a fork of https://www.npmjs.com/package/mocha-sonar-generic-test-coverage but I don't see any open PRs to have the functionality of this module merged back upstream, (though I see some potentially related PRs that are closed).

Are there intentions to have this functionality merged back upstream? Has it already occurred?